### PR TITLE
Add WhatsApp Cloud API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ python main.py
 
 Send a POST request to `http://localhost:8080/chat` with a JSON body like `{"message": "hola"}` and you will get a simple echo reply.
 
+## WhatsApp Integration
+
+Set the following environment variables to enable sending WhatsApp messages using the [WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api):
+
+- `WHATSAPP_TOKEN` – your WhatsApp access token
+- `WHATSAPP_PHONE_ID` – the phone number ID associated with your Meta app
+
+Run the server and send a POST request to `/whatsapp` with a JSON body:
+
+```json
+{
+  "to": "<DESTINATION_PHONE_NUMBER>",
+  "message": "Hola desde la API"
+}
+```
+
+If the request succeeds, the server responds with `{"status": "sent"}`.
+
 ## Deploy to Google Cloud Run
 
 1. [Install the Google Cloud SDK](https://cloud.google.com/sdk) and authenticate:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,12 @@
 import os
+import requests
 from flask import Flask, request, jsonify
 
 app = Flask(__name__)
+
+# WhatsApp Cloud API configuration
+WHATSAPP_TOKEN = os.getenv('WHATSAPP_TOKEN')
+WHATSAPP_PHONE_ID = os.getenv('WHATSAPP_PHONE_ID')
 
 @app.route('/chat', methods=['POST'])
 def chat():
@@ -9,6 +14,40 @@ def chat():
     message = data.get('message', '')
     reply = f"Echo: {message}"
     return jsonify({'reply': reply})
+
+
+@app.route('/whatsapp', methods=['POST'])
+def send_whatsapp():
+    """Send a WhatsApp message using the Cloud API."""
+    if not WHATSAPP_TOKEN or not WHATSAPP_PHONE_ID:
+        return jsonify({'error': 'WhatsApp API not configured'}), 500
+
+    data = request.get_json(silent=True) or {}
+    to = data.get('to')
+    text = data.get('message', '')
+    if not to or not text:
+        return jsonify({'error': 'Missing "to" or "message" field'}), 400
+
+    url = f"https://graph.facebook.com/v18.0/{WHATSAPP_PHONE_ID}/messages"
+    headers = {
+        'Authorization': f'Bearer {WHATSAPP_TOKEN}',
+        'Content-Type': 'application/json',
+    }
+    payload = {
+        'messaging_product': 'whatsapp',
+        'to': to,
+        'type': 'text',
+        'text': {
+            'preview_url': False,
+            'body': text,
+        },
+    }
+
+    resp = requests.post(url, json=payload, headers=headers)
+    if resp.status_code != 200:
+        return jsonify({'error': 'Failed to send message', 'details': resp.text}), 500
+
+    return jsonify({'status': 'sent'})
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 8080))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.3.2
+requests==2.31.0


### PR DESCRIPTION
## Summary
- integrate WhatsApp Cloud API using requests
- document new `/whatsapp` endpoint and required environment variables
- add `requests` dependency

## Testing
- `python -m py_compile main.py deploy_gcloud.py`

------
https://chatgpt.com/codex/tasks/task_e_68545f0a1c048330b8d76c2de4ecd2df